### PR TITLE
Bugfix/issue 1: changelog linebreaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and (optionally):
 ```
 $ git status
 ```
-Also creates a **changelog.txt** file (in your project's root directory), and (optionally) adds a comment in the Trac ticket for each commit.
+Also creates a **changelog.log** file (in your project's root directory), and (optionally) adds a comment in the Trac ticket for each commit.
 
 ## tl;dr
 All of the above is accomplished by running just one command:

--- a/git-add-msg
+++ b/git-add-msg
@@ -14,7 +14,7 @@
 # * (Trac users) run using -r option to automatically add comments, with links to changesets in specified repository, in Trac tickets.
 #
 # author: Heini Fagerlund
-# version: 0.1.2
+# version: 0.1.3
 # license: MIT
 # 
 # Copyright (c) 2015 Heini Fagerlund
@@ -85,16 +85,19 @@ while :
 do
   printf "Enter your commit message (without quote marks; press ctrl-d when done):\n"
   mymultimsg=$(cat)
-  
+  multimsg="${mymultimsg}"
   if [ ! -z "$mymultimsg" -a "$mymultimsg" != " " ]; then
         printf "git committing...\n"
 	git add .
-	git commit -am "#$ticketnum: $mymultimsg" | xclip
+	git commit -F- <<MSG
+$multimsg
+MSG
+        git log --decorate -1 | xclip
         changeset=$( xclip -o ) 
 
         changeset=${changeset%\]*} 
         changeset=${changeset: -7} 
-        xclip -o >> ./changelog.txt ##OPTIONAL: separate log file
+        xclip -o >> ./changelog.log ##OPTIONAL: separate log file
         xclip -o 
          
         mymultimsg=${mymultimsg//&/&amp;} 


### PR DESCRIPTION
Resolves line break display issue #1 for Changelog file. (Newlines are preserved in multi-line commit messages added to changelog.log file).
#### Additional changes:
- Modified format of Changelog file (from .txt to .log).
