### PR TITLE
Fix commit hash in Trac link

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ $ ./acceptanceTests.sh
 **Note**: make sure that [shunit2](https://github.com/kward/shunit2) has been added to your `$PATH`.
 - - -
 ## License
-Copyright (c) Heini Fagerlund. Licensed under the [MIT license](http://opensource.org/licenses/mit-license.php).
+Copyright (c) 2015 Heini Fagerlund. Licensed under the [MIT license](http://opensource.org/licenses/mit-license.php).
 (See [LICENSE](https://github.com/hfagerlund/git-add-msg/blob/master/LICENSE).)
 
 - - -
 ## Changelog
+* 0.2.1 - January 28, 2018. Fixed display of changeset number in auto-generated Trac link.
 * 0.2.0 - January 13, 2016. Deprecated (optional) git status check.
 * 0.1.4 - December 30, 2015. Fixed display of ticket update message.
 * 0.1.3 - December 30, 2015. Newlines in multi-line commit messages now display in Changelog file.

--- a/git-add-msg
+++ b/git-add-msg
@@ -14,10 +14,10 @@
 # * (Trac users) run using -r option to automatically add comments, with links to changesets in specified repository, in Trac tickets.
 #
 # author: Heini Fagerlund
-# version: 0.2.0
+# version: 0.2.1
 # license: MIT
 # 
-# Copyright (c) Heini Fagerlund
+# Copyright (c) 2015 Heini Fagerlund
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -85,14 +85,11 @@ while :
 do
     printf "Enter your commit message (without quote marks; press ctrl-d when done):\n"
     mymultimsg=$(cat)
-    multimsg="${mymultimsg}"
+
     if [ ! -z "$mymultimsg" -a "$mymultimsg" != " " ]; then
         printf "git committing...\n"
         git add .
-        git commit -F- <<MSG
-$multimsg
-MSG
-        git log --decorate -1 | xclip
+	git commit -am "#$ticketnum: $mymultimsg" | xclip
         changeset=$( xclip -o ) 
 
         changeset=${changeset%\]*} 

--- a/trac-service
+++ b/trac-service
@@ -3,7 +3,7 @@
 # Use with git-add-msg to log git commits to Trac using its XML-RPC API
 #
 # author: Heini Fagerlund
-# version: 0.2.0
+# version: 0.2.1
 # license: MIT
 #	
 # The MIT License (MIT)
@@ -11,7 +11,7 @@
 # 
 # The MIT License (MIT)
 # 
-# Copyright (c) Heini Fagerlund
+# Copyright (c) 2015 Heini Fagerlund
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Fixed:
Resolves #9 by (partially) reverting the commit that broke this feature. Identified the problem included *as part of* commit 4a31a1c of [git-add-msg](https://github.com/hfagerlund/git-add-msg/commit/4a31a1cf5219e1122b0f0e5ecd191c2e67484e0a#diff-5fe15ff8bbb973d29ce65f09b7004765) file, when it was bumped from v0.1.2 to v0.1.3.

## Changed:
* bumps version number (to 0.2.1);
* updates Changelog.